### PR TITLE
added support for defered retry timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ monitor.start() // spawn and watch
 
 Optionally you can specify the command to to spawn in the option map as `command: [...]`
 
+If `sleep` is an array of numbers it will use the value at the position of the current number of restarts as the timeout value. If the number of restarts exceed the length of the array it will use the last value in the array until it hits the maxRestarts.
+
+`sleep: [1000, 60000, 60000, 12000, 1000]` will wait 1000ms before retrying, then it will wait 60000 before the next retry and so forth.
+
 ## API
 
 * `monitor.start()` Starts the monitor

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var Monitor = function(command, opts) {
   this.windowsVerbatimArguments = opts.windowsVerbatimArguments
 
   this.crashed = false
-  this.sleep = opts.sleep || 1000
+  this.sleep = Array.isArray(opts.sleep) ? opts.sleep : [opts.sleep || 1000]
   this.maxRestarts = opts.maxRestarts === 0 ? 0 : opts.maxRestarts || 10
   this.kill = opts.kill === false ? false : opts.kill || 30000
 
@@ -155,7 +155,8 @@ Monitor.prototype.start = function() {
       self.status = 'sleeping'
       self.emit('sleep')
 
-      self.timeout = setTimeout(loop, self.sleep)
+      var restartTimeout = self.sleep[restarts - 1] || self.sleep[self.sleep.length - 1]
+      self.timeout = setTimeout(loop, restartTimeout)
     })
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 var test = require('tap').test
 var path = require('path')
+var util = require('util')
 var respawn = require('../index')
 
 var crash = path.join(__dirname, 'apps', 'crash.js')
@@ -232,5 +233,30 @@ test('stop status', function(t) {
     t.same(mon.status, 'stopping')
   })
 
+  mon.start()
+})
+
+test('restart using restart strategy', function (t) {
+  var timeouts = [2, 100, 450, 40]
+  var mon = respawn([node, crash], { maxRestarts: 5, sleep: timeouts})
+  var times = [Date.now()]
+  mon.on('sleep', function() {
+    times.push(Date.now())
+  })
+  mon.on('crash', function() {
+    times.forEach(function(current, key, times) {
+      if (key <= 1) return
+      var previous = times[key - 1]
+      var timeout = timeouts[key - 2] || 0
+      var delta = (current - previous)
+      var gracePeriod = 75
+      t.ok(delta - timeout < gracePeriod, util.format(
+        'should trigger shortly after defined timeout. '
+      + 'Got %d ms, should have stayed within %d-%d ms',
+        delta, timeout, timeout + gracePeriod)
+      )
+    })
+    t.end()
+  })
   mon.start()
 })


### PR DESCRIPTION
The current retry strategy doesn't fit will with scenarios where a database goes down for two minutes just to recover two minutes later. I've implemented a way to define custom restart strategies where it will try timeouts from a given array based on the current retry count.

{ sleep: [100, 200, 1000, 60000] }

First retry will be done after 100 ms, if that fails it will retry in 200ms, then 1000ms, etc.