### PR TITLE
Allow `command` to be a function returning an array.

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,8 @@ Monitor.prototype.start = function() {
   var clock = 60000
 
   var loop = function() {
-    var child = spawn(self.command[0], self.command.slice(1), {
+    var cmd = (typeof(self.command)=='function' ? self.command() : self.command)
+    var child = spawn(cmd[0], cmd.slice(1), {
       cwd: self.cwd,
       env: xtend(process.env, self.env),
       uid: self.uid,
@@ -204,7 +205,7 @@ Monitor.prototype._stopped = function() {
 }
 
 var respawn = function(command, opts) {
-  if (!Array.isArray(command)) return respawn(command.command, command)
+  if (typeof(command) != 'function' && !Array.isArray(command)) return respawn(command.command, command)
   return new Monitor(command, opts || {})
 }
 


### PR DESCRIPTION
We're using respawn + respawn-group to run a set of ffmpeg processes, each generating an output video file. When something goes wrong to have the process respawn, the output filename (and thus the command running it) should change.

With the PR the `command` argument would be allowed to be a function returning the command array.