### PR TITLE
Fix crash count not adding correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,6 +179,8 @@ Monitor.prototype.start = function() {
         restarts = 0
       }
 
+      self.crashes++
+
       if (++restarts > self.maxRestarts && self.maxRestarts !== -1) return self._crash()
 
       self.status = 'sleeping'
@@ -221,7 +223,6 @@ Monitor.prototype.toJSON = function() {
 Monitor.prototype._crash = function() {
   if (this.status !== 'running') return
   this.status = 'crashed'
-  this.crashes++
   this.emit('crash')
   if (this.status === 'crashed') this._stopped()
 }

--- a/index.js
+++ b/index.js
@@ -164,6 +164,7 @@ Monitor.prototype.start = function() {
       self.emit('warn', err) // too opionated? maybe just forward err
       if (!clear()) return
       if (self.status === 'stopping') return self._stopped()
+      self.crashes++
       self._crash()
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -311,3 +311,16 @@ test('fork', function(t) {
 
   mon.start()
 })
+
+test('crashes', function(t) {
+  t.plan(1)
+
+  var mon = respawn([node, crash], {maxRestarts:1, sleep:1})
+  var spawned = 0
+
+  mon.once('stop', function() {
+    t.same(mon.crashes, 2);
+  })
+
+  mon.start()
+})


### PR DESCRIPTION
To fix the issue https://github.com/mafintosh/respawn/issues/19

Here's a testing snippet

```js
test('crashes', function(t) {
  t.plan(1)

  var mon = respawn([node, crash], {maxRestarts:1, sleep:1})

  mon.once('stop', function() {
    t.same(mon.crashes, 2);
  })

  mon.start()
})
```

It will throw an error: `found 1, wanted: 2`
